### PR TITLE
tests: add name for test job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   test:
+    name: run-all-tests
     runs-on: ubuntu-latest
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
This pull request includes a minor update to the GitHub Actions workflow configuration. The change adds a name (`run-all-tests`) to the `test` job in the `.github/workflows/tests.yml` file for better readability and identification.